### PR TITLE
Keyboard shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "clsx": "^2.1.1",
     "cmdk-solid": "^1.1.0",
     "color-hash": "^2.0.2",
+    "hotkeys-js": "^3.13.9",
     "lodash-es": "^4.17.21",
     "lucide-solid": "^0.468.0",
     "nanoid": "^5.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       color-hash:
         specifier: ^2.0.2
         version: 2.0.2
+      hotkeys-js:
+        specifier: ^3.13.9
+        version: 3.13.9
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1152,6 +1155,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hotkeys-js@3.13.9:
+    resolution: {integrity: sha512-3TRCj9u9KUH6cKo25w4KIdBfdBfNRjfUwrljCLDC2XhmPDG0SjAZFcFZekpUZFmXzfYoGhFDcdx2gX/vUVtztQ==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -3023,6 +3029,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hotkeys-js@3.13.9: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -5,7 +5,7 @@ import * as ComboboxPrimitive from '@kobalte/core/combobox';
 import type { PolymorphicProps } from '@kobalte/core/polymorphic';
 
 import { cn } from '~/lib/utils';
-import ChevronDownIcon from '~/lib/icons/chevron-down-solid.svg'
+import ChevronDownIcon from 'lucide-solid/icons/chevron-down';
 
 const Combobox = ComboboxPrimitive.Root;
 const ComboboxItemLabel = ComboboxPrimitive.ItemLabel;
@@ -125,11 +125,7 @@ const ComboboxTrigger = <T extends ValidComponent = 'button'>(
   const [local, others] = splitProps(props as ComboboxTriggerProps, ['class', 'children']);
   return (
     <ComboboxPrimitive.Trigger class={cn('size-4 opacity-50', local.class)} {...others}>
-      <ComboboxPrimitive.Icon>
-        {local.children ?? (
-          <ChevronDownIcon />
-        )}
-      </ComboboxPrimitive.Icon>
+      <ComboboxPrimitive.Icon>{local.children ?? <ChevronDownIcon />}</ComboboxPrimitive.Icon>
     </ComboboxPrimitive.Trigger>
   );
 };

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,13 +21,13 @@ const Command: Component<ParentProps<CommandPrimitive.CommandRootProps>> = (prop
   )
 }
 
-const CommandDialog: Component<ParentProps<DialogRootProps>> = (props) => {
-  const [local, others] = splitProps(props, ["children"])
+const CommandDialog: Component<ParentProps<DialogRootProps & { commandProps: CommandPrimitive.CommandRootProps}>> = (props) => {
+  const [local, others] = splitProps(props, ["children", 'commandProps'])
 
   return (
     <Dialog {...others}>
       <DialogContent class="overflow-hidden p-0">
-        <Command class="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5">
+        <Command {...local.commandProps} class="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5">
           {local.children}
         </Command>
       </DialogContent>

--- a/src/lib/shortcuts/command-palette.module.css
+++ b/src/lib/shortcuts/command-palette.module.css
@@ -1,0 +1,6 @@
+
+.container {
+  pointer-events: initial;
+  margin: auto;
+  max-width: 80ch;
+}

--- a/src/lib/shortcuts/command-palette.tsx
+++ b/src/lib/shortcuts/command-palette.tsx
@@ -1,0 +1,48 @@
+import hotkeys from 'hotkeys-js';
+import { createSignal, onMount, Show } from 'solid-js';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '~/components/ui/command';
+import style from './command-palette.module.css'
+
+export default function CommandPalette(props) {
+  const [isOpen, setIsOpen] = createSignal(false);
+  onMount(() => {
+    hotkeys('ctrl+space', function (event, handler) {
+      event.preventDefault();
+      setIsOpen(open => !open);
+    });
+    return () => {
+      hotkeys.unbind('ctrl+space');
+    };
+  });
+
+  return (
+    <Show when={isOpen()}>
+      <Command class={style.container}>
+        <CommandInput autofocus placeholder='Type a command or search...' />
+        <CommandList>
+          <CommandEmpty>No results found.</CommandEmpty>
+          <CommandGroup heading='Deck'>
+            <CommandItem>Draw</CommandItem>
+            <CommandItem>Calendar</CommandItem>
+            <CommandItem>Search Emoji</CommandItem>
+            <CommandItem>Calculator</CommandItem>
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading='Settings'>
+            <CommandItem>Profile</CommandItem>
+            <CommandItem>Billing</CommandItem>
+            <CommandItem>Settings</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    </Show>
+  );
+}

--- a/src/lib/shortcuts/commands/deck.ts
+++ b/src/lib/shortcuts/commands/deck.ts
@@ -1,0 +1,49 @@
+import { Card } from '~/lib/constants';
+import { doXTimes } from '~/lib/globals';
+import { PlayArea } from '~/lib/playArea';
+import { transferCard } from '~/lib/transferCard';
+
+export function drawCards(playArea: PlayArea, count: number = 1) {
+  doXTimes(count, () => playArea.draw());
+}
+
+export function peekFromTop(playArea: PlayArea, count = 1) {
+  doXTimes(count, () => transferCard(playArea.deck.cards[0], playArea.deck, playArea.peekZone), 25);
+}
+
+export function searchDeck(playArea: PlayArea) {
+  peekFromTop(playArea, playArea.deck.cards.length);
+}
+
+export function discardFromTop(playArea: PlayArea, count = 1) {
+  doXTimes(
+    count,
+    () => transferCard(playArea.deck.cards[0], playArea.deck, playArea.graveyardZone),
+    25
+  );
+}
+
+export function exileFromTop(playArea: PlayArea, count = 1) {
+  doXTimes(
+    count,
+    () => transferCard(playArea.deck.cards[0], playArea.deck, playArea.exileZone),
+    25
+  );
+}
+
+export function getNextLandIndex(cards: Card[]) {
+  const count = cards.findIndex(card => card.detail.type_line.toLowerCase().includes('land'));
+  console.log(count);
+  return count;
+}
+
+export function revealFromTop(playArea: PlayArea, count = 1) {
+  doXTimes(
+    count,
+    () => {
+      playArea.reveal(playArea.deck.cards[0]);
+      transferCard(playArea.deck.cards[0], playArea.deck, playArea.peekZone);
+    },
+    25
+  );
+}

--- a/src/lib/shortcuts/commands/field.ts
+++ b/src/lib/shortcuts/commands/field.ts
@@ -1,0 +1,10 @@
+import { Mesh } from 'three';
+import { PlayArea } from '~/lib/playArea';
+
+export function untapAll(playArea: PlayArea) {
+  let tappedCards = playArea.battlefieldZone.mesh.children.filter(
+    mesh => mesh.userData.isTapped
+  ) as Mesh[];
+
+  tappedCards.forEach(card => playArea.tap(card));
+}

--- a/src/lib/transferCard.ts
+++ b/src/lib/transferCard.ts
@@ -19,7 +19,7 @@ export async function transferCard<AddOptions extends {}>(
   }: ExtendedOptions<AddOptions> = {}
 ) {
   await fromZone.removeCard?.(card.mesh);
-  if (toZone?.zone !== 'battlefield') {
+  if (toZone && toZone?.zone !== 'battlefield') {
     if (card.mesh.userData.isToken) {
       addOptions.destroy = true;
     }

--- a/src/lib/ui/cardBattlefieldMenu.tsx
+++ b/src/lib/ui/cardBattlefieldMenu.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, For, Show } from 'solid-js';
+import { Component, createSignal, For, onMount, Show } from 'solid-js';
 import { Mesh } from 'three';
 import { Button } from '~/components/ui/button';
 import {
@@ -24,9 +24,11 @@ import { cardsById, doXTimes } from '../globals';
 import { PlayArea } from '../playArea';
 import { counters, setIsCounterDialogOpen } from './counterDialog';
 import MoveMenu from './moveMenu';
+import hotkeys from 'hotkeys-js';
 
 const CardBattlefieldMenu: Component<{ playArea: PlayArea; cardMesh?: Mesh }> = props => {
   let card = () => cardsById.get(props.cardMesh?.userData.id)!;
+
 
   return (
     <Menubar>
@@ -37,7 +39,7 @@ const CardBattlefieldMenu: Component<{ playArea: PlayArea; cardMesh?: Mesh }> = 
             onClick={() => {
               props.playArea.flip(props.cardMesh);
             }}>
-            Flip
+            Flip<MenubarShortcut>F</MenubarShortcut>
           </MenubarItem>
           <MenubarSub overlap>
             <MenubarSubTrigger>Counters</MenubarSubTrigger>
@@ -93,7 +95,7 @@ const CardBattlefieldMenu: Component<{ playArea: PlayArea; cardMesh?: Mesh }> = 
           </MenubarSub>
           <MenubarSub overlap>
             <MenubarSubTrigger onClick={() => props.playArea.clone(props.cardMesh?.userData.id)}>
-              Clone
+              Clone<MenubarShortcut>C</MenubarShortcut>
             </MenubarSubTrigger>
             <MenubarSubContent>
               <div class='pt-1.5 px-2'>Clone {props.cardMesh?.userData?.card?.detail?.name}</div>

--- a/src/lib/ui/deckEditor.tsx
+++ b/src/lib/ui/deckEditor.tsx
@@ -31,7 +31,7 @@ import { getCardArtImage, getCardImage } from '../card';
 import { FORMATS } from '../constants';
 import { fetchCardInfo, loadCardList } from '../deck';
 import { colorHashDark } from '../globals';
-import CircleInfoIcon from '../icons/circle-info-solid.svg';
+import CircleInfoIcon from 'lucide-solid/icons/info';
 import { cn } from '../utils';
 import styles from './deckEditor.module.css';
 
@@ -180,7 +180,7 @@ export const DeckEditor: Component<Props> = props => {
                   </div>
                   <HoverCard openDelay={100}>
                     <HoverCardTrigger>
-                      <CircleInfoIcon class='fill-sky-700 hover:fill-sky-600' />
+                      <CircleInfoIcon class='text-sky-500 hover:text-sky-400' />
                     </HoverCardTrigger>
                     <HoverCardContent>
                       <p>Supported cardlist formats:</p>

--- a/src/lib/ui/deckMenu.tsx
+++ b/src/lib/ui/deckMenu.tsx
@@ -11,9 +11,15 @@ import {
   MenubarTrigger,
 } from '~/components/ui/menubar';
 import NumberFieldMenuItem from '~/components/ui/number-field-menu-item';
-import { doXTimes } from '../globals';
 import { PlayArea } from '../playArea';
-import { transferCard } from '../transferCard';
+import {
+  discardFromTop,
+  drawCards,
+  exileFromTop,
+  peekFromTop,
+  revealFromTop,
+  searchDeck,
+} from '../shortcuts/commands/deck';
 
 const DeckMenu: Component<{ playArea: PlayArea }> = props => {
   function getNextLandIndex() {
@@ -22,29 +28,12 @@ const DeckMenu: Component<{ playArea: PlayArea }> = props => {
     );
   }
 
-  function discardTopDeck() {
-    transferCard(props.playArea.deck.cards[0], props.playArea.deck, props.playArea.graveyardZone);
-  }
-
-  function exileTopDeck() {
-    transferCard(props.playArea.deck.cards[0], props.playArea.deck, props.playArea.exileZone);
-  }
-
-  function peekTopDeck() {
-    transferCard(props.playArea.deck.cards[0], props.playArea.deck, props.playArea.peekZone);
-  }
-
   return (
     <Menubar>
       <MenubarMenu>
         <MenubarTrigger>Deck | {props.playArea.deck.observable.cardCount} cards</MenubarTrigger>
         <MenubarContent>
-          <MenubarItem
-            onClick={() => {
-              doXTimes(props.playArea.deck.cards.length, peekTopDeck, 25);
-            }}>
-            Search
-          </MenubarItem>
+          <MenubarItem onClick={() => searchDeck(props.playArea)}>Search</MenubarItem>
           <MenubarSub overlap>
             <MenubarSubTrigger openDelay={50} onClick={() => props.playArea.draw()}>
               Draw
@@ -53,57 +42,49 @@ const DeckMenu: Component<{ playArea: PlayArea }> = props => {
               <div class='py-1.5 px-2'>Draw</div>
               <NumberFieldMenuItem
                 defaultValue={7}
-                onSubmit={count => {
-                  doXTimes(count, () => props.playArea.draw());
-                }}
+                onSubmit={count => drawCards(props.playArea, count)}
               />
             </MenubarSubContent>
           </MenubarSub>
           <MenubarSub overlap>
-            <MenubarSubTrigger onClick={discardTopDeck}>Discard</MenubarSubTrigger>
+            <MenubarSubTrigger onClick={() => discardFromTop(props.playArea)}>
+              Discard
+            </MenubarSubTrigger>
             <MenubarSubContent>
               <div class='py-1.5 px-2'>Discard</div>
-              <NumberFieldMenuItem
-                onSubmit={count => {
-                  doXTimes(count, discardTopDeck);
-                }}
-              />
+              <NumberFieldMenuItem onSubmit={count => discardFromTop(props.playArea, count)} />
               <MenubarItem
                 closeOnSelect={false}
-                onClick={() => doXTimes(getNextLandIndex() + 1, discardTopDeck)}>
+                onClick={() => discardFromTop(props.playArea, getNextLandIndex() + 1)}>
                 Discard all cards to next land
               </MenubarItem>
             </MenubarSubContent>
           </MenubarSub>
           <MenubarSub overlap>
-            <MenubarSubTrigger onClick={exileTopDeck}>Exile</MenubarSubTrigger>
+            <MenubarSubTrigger onClick={() => exileFromTop(props.playArea)}>
+              Exile
+            </MenubarSubTrigger>
             <MenubarSubContent>
               <div class='py-1.5 px-2'>Exile</div>
               <NumberFieldMenuItem
                 onSubmit={count => {
-                  doXTimes(count, exileTopDeck);
+                  exileFromTop(props.playArea, count);
                 }}
               />
               <MenubarItem
                 closeOnSelect={false}
-                onClick={() => doXTimes(getNextLandIndex() + 1, exileTopDeck)}>
+                onClick={() => exileFromTop(props.playArea, getNextLandIndex() + 1)}>
                 Exile all cards to next land
               </MenubarItem>
             </MenubarSubContent>
           </MenubarSub>
           <MenubarSub>
-            <MenubarSubTrigger onClick={peekTopDeck}>Peek</MenubarSubTrigger>
+            <MenubarSubTrigger onClick={() => peekFromTop(props.playArea)}>Peek</MenubarSubTrigger>
             <MenubarSubContent>
               <div class='py-1.5 px-2'>Peek</div>
-              <NumberFieldMenuItem
-                onSubmit={count => {
-                  doXTimes(count, peekTopDeck);
-                }}
-              />
+              <NumberFieldMenuItem onSubmit={count => peekFromTop(props.playArea, count)} />
               <MenubarItem
-                onClick={() => {
-                  doXTimes(props.playArea.deck.cards.length, peekTopDeck, 50);
-                }}>
+                onClick={() => peekFromTop(props.playArea, props.playArea.deck.cards.length)}>
                 Peek All
               </MenubarItem>
             </MenubarSubContent>
@@ -112,29 +93,13 @@ const DeckMenu: Component<{ playArea: PlayArea }> = props => {
             <MenubarSubTrigger>Reveal</MenubarSubTrigger>
             <MenubarSubContent>
               <div class='py-1.5 px-2'>Reveal</div>
-              <NumberFieldMenuItem
-                onSubmit={async count => {
-                  doXTimes(count, () => {
-                    let card = props.playArea.deck.cards[0];
-                    props.playArea.reveal(card);
-                    peekTopDeck();
-                  });
-                }}
-              />
+              <NumberFieldMenuItem onSubmit={async count => revealFromTop(props.playArea, count)} />
               <MenubarItem
                 onClick={() => {
                   if (props.playArea.tokenSearchZone.cards.length) {
                     props.playArea.dismissFromZone(props.playArea.tokenSearchZone);
                   }
-                  doXTimes(
-                    props.playArea.deck.cards.length,
-                    () => {
-                      let card = props.playArea.deck.cards[0];
-                      props.playArea.reveal(card);
-                      peekTopDeck();
-                    },
-                    50
-                  );
+                  revealFromTop(props.playArea, props.playArea.deck.cards.length);
                 }}>
                 Reveal All
               </MenubarItem>
@@ -165,9 +130,7 @@ const DeckMenu: Component<{ playArea: PlayArea }> = props => {
               <div class='py-1.5 px-2'>Mulligan for x cards</div>
               <NumberFieldMenuItem
                 defaultValue={7}
-                onSubmit={async count => {
-                  props.playArea.mulligan(count);
-                }}
+                onSubmit={async count => props.playArea.mulligan(count)}
               />
             </MenubarSubContent>
           </MenubarSub>

--- a/src/lib/ui/deckPicker.tsx
+++ b/src/lib/ui/deckPicker.tsx
@@ -22,7 +22,7 @@ import {
 } from '~/components/ui/text-field';
 import { createDeckStore } from '../deckStore';
 import { colorHashDark, startSpectating } from '../globals';
-import PencilIcon from '../icons/pencil-solid.svg';
+import PencilIcon from 'lucide-solid/icons/pencil';
 import { cn } from '../utils';
 import { DeckEditor } from './deckEditor';
 import styles from './deckPicker.module.css';
@@ -128,7 +128,7 @@ const DeckPicker: Component = props => {
                       </button>
                       <div class='absolute top-2 right-2'>
                         <button type='button' onClick={() => setEditingDeck(deck)}>
-                          <PencilIcon style='height: 1.25rem; fill: white; stroke: black; stroke-width: 2px;' />
+                          <PencilIcon />
                         </button>
                       </div>
                     </div>

--- a/src/lib/ui/log.tsx
+++ b/src/lib/ui/log.tsx
@@ -90,6 +90,21 @@ export function parseLogEntry(entry) {
           revealed <strong>{card?.detail.name}</strong>
         </>
       );
+    case 'roll':
+      console.log(entry.payload);
+      return (
+        <>
+          rolled{' '}
+          <For each={entry.payload.roll}>
+            {die => (
+              <>
+                [d{die.sides}] <strong>{die.result}</strong>{' '}
+              </>
+            )}
+          </For>
+          Total: <strong>{entry.payload.roll.reduce((a, b) => a + b.result, 0)}</strong>
+        </>
+      );
 
     default:
       return `${entry.type} ${cardReference()}`;

--- a/src/lib/ui/overlay.tsx
+++ b/src/lib/ui/overlay.tsx
@@ -31,6 +31,7 @@ import {
   DialogTrigger,
 } from '~/components/ui/dialog';
 import { Button } from '~/components/ui/button';
+import CommandPalette from '../shortcuts/command-palette';
 
 const Overlay: Component = () => {
   let userData = () => hoverSignal()?.mesh?.userData;
@@ -198,6 +199,7 @@ const Overlay: Component = () => {
       <RevealMenu />
       <TokenSearchMenu />
       <CounterDialog />
+      <CommandPalette />
     </div>
   );
 };

--- a/src/lib/ui/overlay.tsx
+++ b/src/lib/ui/overlay.tsx
@@ -199,7 +199,7 @@ const Overlay: Component = () => {
       <RevealMenu />
       <TokenSearchMenu />
       <CounterDialog />
-      <CommandPalette />
+      <CommandPalette playArea={playArea} />
     </div>
   );
 };

--- a/src/lib/ui/playerMenu.tsx
+++ b/src/lib/ui/playerMenu.tsx
@@ -17,7 +17,7 @@ import {
 } from '~/components/ui/number-field';
 import { playAreas, provider } from '../globals';
 import { counters, setIsCounterDialogOpen } from './counterDialog';
-import ChevronDownIcon from '~/lib/icons/chevron-down-solid.svg';
+import ChevronDownIcon from 'lucide-solid/icons/chevron-down';
 
 export const LocalPlayer: Component = props => {
   const [open, setOpen] = createSignal(true);
@@ -54,17 +54,18 @@ export const LocalPlayer: Component = props => {
                   life: parseInt(value, 10),
                 });
               }}>
-              <div class='relative' style='display: inline-block'>
+              <div class='relative rounded-md' style='display: inline-block;'>
                 <NumberFieldInput />
                 <NumberFieldIncrementTrigger />
                 <NumberFieldDecrementTrigger />
               </div>
             </NumberField>
             <CollapsibleTrigger class='size-4'>
-              {/* <svg height='1rem' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'>
-                <path d='M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z' />
-              </svg> */}
-              <ChevronDownIcon />
+              <ChevronDownIcon
+                style={`transform: rotate3d(1,0,0,${
+                  open() ? 180 : 0
+                }deg); transition: transform 250ms ease-in-out;`}
+              />
             </CollapsibleTrigger>
           </div>
           <Show when={!open()}>
@@ -85,7 +86,7 @@ export const LocalPlayer: Component = props => {
                         return false;
                       }}
                       onClick={e => changeCounter(counterId, x => x + 1)}
-                      style={`background-color: ${counter.color}; min-width: 2rem; height:2rem; line-height: 2rem;`}>
+                      style={`background-color: ${counter.color}; color: black; min-width: 2rem; height:2rem; line-height: 2rem;`}>
                       {props?.counters[counterId]}
                     </button>
                   );
@@ -139,17 +140,17 @@ export const LocalPlayer: Component = props => {
             <ul class='space-y-2'>
               <For
                 each={Object.entries(props?.counters ?? {})
-                  // .filter(entry => entry[1] !== 0)
                   .map(entry => entry[0])
                   .sort((a, b) => a.localeCompare(b))}>
                 {counterId => {
                   let counter = counters().find(c => c.id === counterId);
                   return (
-                    <li class='flex justify-between text-gray-600'>
+                    <li class='flex justify-between items-center'>
                       <span style='text-align: start;'>{counter.name}</span>
                       <span class='font-semibold'>
                         <NumberField
-                          style={`width: 6rem; background-color: ${counter.color}`}
+                          class='rounded-md'
+                          style={`width: 6rem; background-color: ${counter.color}; color: black`}
                           onChange={rawValue => {
                             let value = parseInt(rawValue, 10);
                             if (isNaN(value)) value = 0;
@@ -209,7 +210,7 @@ export const NetworkPlayer: Component = props => {
                         return false;
                       }}
                       onClick={e => changeCounter(counterId, x => x + 1)}
-                      style={`background-color: ${counter.color}; min-width: 2rem; height:2rem; line-height: 2rem;`}>
+                      style={`background-color: ${counter.color}; color: black; min-width: 2rem; height:2rem; line-height: 2rem;`}>
                       {props?.counters[counterId]}
                     </button>
                   );
@@ -233,7 +234,7 @@ export const NetworkPlayer: Component = props => {
                       <span class='font-semibold'>
                         <NumberField
                           disabled
-                          style={`width: 6rem; background-color: ${counter.color}`}
+                          style={`width: 6rem; background-color: ${counter.color}; color: black;`}
                           onChange={rawValue => {
                             let value = parseInt(rawValue, 10);
                             if (isNaN(value)) value = 0;

--- a/src/lib/ui/revealMenu.tsx
+++ b/src/lib/ui/revealMenu.tsx
@@ -1,4 +1,4 @@
-import { Component, Show } from 'solid-js';
+import { Component, createEffect, createMemo, Show } from 'solid-js';
 import { Command, CommandInput } from '~/components/ui/command';
 import {
   Menubar,
@@ -21,11 +21,16 @@ import { cleanupCard } from '../card';
 const RevealMenu: Component = props => {
   let userData = () => hoverSignal()?.mesh?.userData;
   const isPublic = () => userData()?.isPublic;
-  const isOwner = () => userData()?.clientId === provider.awareness.clientID;
-  const location = () => userData()?.location;
+  const isOwner = createMemo(() => userData()?.clientId === provider.awareness.clientID);
+  const location = createMemo(() => userData()?.location);
   const cardMesh = () => hoverSignal()?.mesh;
   const tether = () => hoverSignal()?.tether;
   const playArea = playAreas[provider.awareness.clientID];
+  let inputRef;
+
+  createEffect(() => {
+    if (location() === 'reveal' && inputRef) inputRef.focus();
+  });
 
   return (
     <>
@@ -37,7 +42,13 @@ const RevealMenu: Component = props => {
         <div class={styles.search}>
           <Command>
             <CommandInput
+              ref={inputRef}
               placeholder='Search'
+              onKeyUp={e => {
+                if (e.code === 'Escape') {
+                  playArea.dismissFromZone(playArea.revealZone);
+                }
+              }}
               onValueChange={value => {
                 setPeekFilterText(value);
               }}

--- a/src/lib/ui/tokenMenu.tsx
+++ b/src/lib/ui/tokenMenu.tsx
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { Component, createSignal, Match, Show, Switch } from 'solid-js';
+import { Component, createEffect, createMemo, createSignal, Match, Show, Switch } from 'solid-js';
 import { Button } from '~/components/ui/button';
 import { Command, CommandInput } from '~/components/ui/command';
 import { Menubar, MenubarContent, MenubarMenu, MenubarTrigger } from '~/components/ui/menubar';
@@ -20,12 +20,13 @@ import styles from './peekMenu.module.css';
 const TokenSearchMenu: Component = props => {
   let userData = () => hoverSignal()?.mesh?.userData;
   const isPublic = () => userData()?.isPublic;
-  const isOwner = () => userData()?.clientId === provider.awareness.clientID;
-  const location = () => userData()?.location;
+  const isOwner = createMemo(() => userData()?.clientId === provider.awareness.clientID);
+  const location = createMemo(() => userData()?.location);
   const cardMesh = () => hoverSignal()?.mesh;
   const tether = () => hoverSignal()?.tether;
   const playArea = playAreas[provider.awareness.clientID];
   const [viewField, setViewField] = createSignal(false);
+  let inputRef;
 
   function addToBattlefield(referenceCard: Card) {
     let card = cloneCard(referenceCard, nanoid());
@@ -43,6 +44,10 @@ const TokenSearchMenu: Component = props => {
       },
     });
   }
+
+  createEffect(() => {
+    if (location() === 'tokenSearch' && inputRef) inputRef.focus();
+  });
 
   return (
     <>
@@ -81,7 +86,13 @@ const TokenSearchMenu: Component = props => {
             </h2>
             <Command>
               <CommandInput
+                ref={inputRef}
                 placeholder='Search'
+                onKeyUp={e => {
+                  if (e.code === 'Escape') {
+                    playArea.dismissFromZone(playArea.tokenSearchZone);
+                  }
+                }}
                 onValueChange={value => {
                   setPeekFilterText(value);
                 }}


### PR DESCRIPTION
feat: add command palette
feat: add deck commands to palette
feat: add log only dice roll to command palette
feat: add keyboard shortcuts

battlefield:
c clone 
t tap
f flip

global:
d draw 
s search deck
shift+u untap all

global card actions:
b send to battlefield
ctrl+d destroy
e exile
p peek


card grid:
esc close menu


feat: card grids auto focus search on open
fix: properly dispose of cards when closing token menu



